### PR TITLE
If no image name specified, it should print Default configuration details

### DIFF
--- a/atomic
+++ b/atomic
@@ -115,9 +115,10 @@ class Atomic:
             pass
 
         if not self.name:
-            self.name = self.image.split("/")[-1].split(":")[0]
-            if self.spc:
-                self.name = self.name + "-spc"
+			if self.name is not None:
+				self.name = self.image.split("/")[-1].split(":")[0]
+			if self.spc:
+				self.name = self.name + "-spc"
 
     def run(self):
         try:


### PR DESCRIPTION
To fix this:

```
-bash-4.2# ./atomic defaults
Traceback (most recent call last):
  File "./atomic", line 355, in <module>
    atomic.set_args(args)
  File "./atomic", line 118, in set_args
    self.name = self.image.split("/")[-1].split(":")[0]
AttributeError: 'NoneType' object has no attribute 'split'
```