### PR TITLE
Fix error when image already exists with Labels

### DIFF
--- a/atomic
+++ b/atomic
@@ -272,10 +272,10 @@ class Atomic(object):
                 cmd = self.gen_cmd(args)
                 print(cmd)
 
-            return(subprocess.check_call(cmd, env={
-                "CONFDIR": "/etc/%s" % self.name,
-                "LOGDIR": "/var/log/%s" % self.name,
-                "DATADIR":"/var/lib/%s" % self.name}, shell=True))
+                return(subprocess.check_call(cmd, env={
+                    "CONFDIR": "/etc/%s" % self.name,
+                    "LOGDIR": "/var/log/%s" % self.name,
+                    "DATADIR":"/var/lib/%s" % self.name}, shell=True))
 
     def help(self):
         if os.path.exists("/usr/bin/rpm-ostree"):


### PR DESCRIPTION
After pulling the rheltools image, I tried to perform `atomic install` on it to see what happened

```
$ sudo docker images
REPOSITORY                TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
rhel-tools-docker-7.1-1   latest              a2893926ea0f        6 hours ago         850.9 MB
[cloud-user@atomic-20150125 ~]$ sudo /usr/local/bin/atomic install rhel-tools-docker-7.1-1
Traceback (most recent call last):
  File "/usr/local/bin/atomic", line 396, in <module>
    sys.exit(args.func())
  File "/usr/local/bin/atomic", line 274, in install
    return(subprocess.check_call(cmd, env={
UnboundLocalError: local variable 'cmd' referenced before assignment
```

I think this commit should fix that error.